### PR TITLE
Updated to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minimal-yaml"
 version = "0.1.5"
 authors = ["Nathan Whitaker <nathan.whitaker01@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A minimalist, zero-copy parser for a strict subset of the YAML specification."
 readme = "README.md"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,15 +5,6 @@ use std::str::Bytes;
 
 use crate::Result;
 
-// Implementation lifted from std, as it's currently only on Nightly. It's such a simple macro that it's low risk to duplicate it here (and better than writing one myself)
-macro_rules! matches {
-    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?) => {
-        match $expression {
-            $( $pattern )|+ $( if $guard )? => true,
-            _ => false
-        }
-    }
-}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ParseContext {
     FlowIn,
@@ -210,7 +201,7 @@ impl<'a, 'b> Parser<'a> {
             }
             b'-' => match self.peek() {
                 Some(byt) if byt.is_linebreak() || byt.is_ws() => self.parse_sequence_block()?,
-                byt => unreachable!(format!("unexpected {:?}", byt.map(char::from))),
+                byt => unreachable!("unexpected {:?}", byt.map(char::from)),
             },
 
             b'}' | b']' => {


### PR DESCRIPTION
Also removed the custom "Matches" macro, as it has been included in the stable compiler